### PR TITLE
Remove comma from sample budget.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This sample `budget.json` file below contains two `Budget` objects:
          {
             "resourceType":"script",
             "budget":150
-         },
+         }
       ],
       "resourceCounts":[
          {


### PR DESCRIPTION
Hey.

Sample budget.json format is fixed in this MR.